### PR TITLE
fix: Support "title" in schema

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 const ALLOWED_SCHEMA_KEYS = [
   'type',
   'format',
+  'title',
   'description',
   'items',
   'default',


### PR DESCRIPTION
Title is a supported property in the spec and is used in redoc: https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.0.md#schema-object