### PR TITLE
feat: Support redoc's x-tagGroups

### DIFF
--- a/lib/openapi/constructor.js
+++ b/lib/openapi/constructor.js
@@ -65,6 +65,10 @@ module.exports = ({options = {}, getSchemas = null, routes = []} = {}) => {
     if (swagger.tags) {
       swaggerObject.tags = swagger.tags;
     }
+    if (swagger['x-tagGroups']) {
+      // redoc extension
+      swaggerObject['x-tagGroups'] = swagger['x-tagGroups'];
+    }
     if (swagger.externalDocs) {
       swaggerObject.externalDocs = swagger.externalDocs;
     }


### PR DESCRIPTION
Pass redoc's x-tagGroups extension through to swagger
This feels a bit dirty putting client-specific extensions in here, but it was the simplest way to move forward. Perhaps it should just copy all properties, instead?