### PR TITLE
feat: Support operationId

### DIFF
--- a/lib/openapi/constructor.js
+++ b/lib/openapi/constructor.js
@@ -164,6 +164,10 @@ module.exports = ({options = {}, getSchemas = null, routes = []} = {}) => {
           swaggerMethod.security = schema.security;
         }
 
+        if (schema.operationId) {
+          swaggerMethod.operationId = schema.operationId;
+        }
+
         if (schema.querystring) {
           helpers.genQuery(parameters, schema.querystring);
         }


### PR DESCRIPTION
OperationId is part of the spec and is pretty handy if using the swagger codegen tools: https://swagger.io/docs/specification/paths-and-operations/#operationid