### PR TITLE
Add "exposeRoute:true" in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ app.register(oas, {
     consumes: ['application/json'],
     produces: ['application/json'],
   },
+  exposeRoute: true
 });
 
 // put some routes and schemas


### PR DESCRIPTION
The default of `exposeRoute` is `false` which leads to a 404 error:

{"message":"Route GET:/documentation not found","error":"Not Found","statusCode":404}