### PR TITLE
Feature/add oas examples support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,68 @@ app.ready(err => {
 });
 ```
 
+Please note, the schema format for Fastify routes is [JSONSchema](https://github.com/fastify/fastify/blob/v2.13.0/docs/Routes.md#routes-option) and you may encounter some differences in the format for route spec vs. output OpenAPI spec.  
+This plugin includes handling around a few of these differences.
+
+One such case is the `example` or `examples` keywords:
+```js
+fastify.route({
+  method: 'POST',
+  url: '/',
+  schema: {
+    body: {
+      type: 'object',
+      description: 'an object',
+      examples: [
+          {
+            name: 'Object Sample',
+            summary: 'an example',
+            value: {a: 'payload'},
+          }
+      ],
+      properties: {
+        a: {type: 'string', description: 'your payload'}
+      }
+    }
+  },
+  handler: // ...
+})
+```
+Which produces a spec similar to:
+```json
+{
+  ... 
+
+  "content": {
+    "application/json": {
+      "examples": {
+        "Object Sample": {
+          "summary": "an example",
+          "value": {
+            "a": "payload"
+          }
+        }
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string",
+            "description": "your payload"
+          }
+        }
+      }
+    }
+  }
+}
+```
+(in this case, the name property is extracted as the examples key)
+
 <sub>[Back to top](#toc)</sub>
 
 ### Docs
 
-See [Docs](/docs/README.md) for more details. 
+See [Docs](/docs/README.md) for more details on the TypeScript types that you may use when working with OpenAPI spec.
 
 ### Plugin options
 

--- a/__tests__/lib/helpers.spec.js
+++ b/__tests__/lib/helpers.spec.js
@@ -125,6 +125,70 @@ describe('helpers', () => {
       helpers.genBody(dst, body, ['application/json']);
       expect(dst).toEqual(expected);
     });
+    test('generates valid body with examples', () => {
+      const body = {
+        type: 'object',
+        description: 'lalala',
+        required: ['a', 'b'],
+        examples: [
+          {
+            name: 'Capital Letters',
+            summary: 'All string values are capitals',
+            value: {a: 'A', b: 'D', c: 0},
+          },
+          {
+            name: 'Default values',
+            summary: 'Using enum defaults',
+            value: {a: 'A', c: 0},
+          },
+        ],
+        properties: {
+          a: {type: 'string', description: 'A value'},
+          b: {
+            type: 'string',
+            enum: ['C', 'D'],
+            default: 'C',
+          },
+          c: {
+            type: 'number',
+            minimum: 0,
+            maximum: 100,
+          },
+        },
+      };
+      const expected = {
+        description: 'lalala',
+        required: true,
+        content: {
+          'application/json': {
+            examples: {
+              'Capital Letters': {
+                summary: 'All string values are capitals',
+                value: {a: 'A', b: 'D', c: 0},
+              },
+              'Default values': {
+                summary: 'Using enum defaults',
+                value: {a: 'A', c: 0},
+              },
+            },
+            schema: {
+              type: 'object',
+              required: ['a', 'b'],
+              properties: {
+                a: {type: 'string', description: 'A value'},
+                b: {type: 'string', enum: ['C', 'D'], default: 'C'},
+                c: {type: 'number', minimum: 0, maximum: 100},
+              },
+            },
+          },
+        },
+      };
+
+      const dst = {};
+      helpers.genBody(dst, body, ['application/json']);
+
+      expect(dst).toEqual(expected);
+    });
   });
 
   describe('genHeaders', () => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -94,7 +94,12 @@ exports.genBody = (dst, src, consumes) => {
 
   for (const mediaType of mediaTypes) {
     dst.content[mediaType] = {};
-    if (body.example) {
+    if (body.examples) {
+      dst.content[mediaType].examples = Object.fromEntries(
+        body.examples.map(({name, ...rest}) => [name, rest]),
+      );
+      delete body.examples;
+    } else if (body.example) {
       dst.content[mediaType].example = body.example;
       delete body.example;
     }


### PR DESCRIPTION
Fixes #26 and coerces JSONSchema `examples` array into object. Update documentation with this difference.