### PR TITLE
fix: fixed a typo in constructor.js (getPath → getQuery)

### DIFF
--- a/lib/openapi/constructor.js
+++ b/lib/openapi/constructor.js
@@ -225,7 +225,7 @@ module.exports = ({
               if (refValue.indexOf('#') === refValue.length - 1) {
                 const schemaId = refValue.substring(0, refValue.indexOf('#'));
                 const resolved = getSchema(schemaId);
-                helpers.genPath(parameters, resolved);
+                helpers.genQuery(parameters, resolved);
               }
             });
           } else {


### PR DESCRIPTION
This mistakenly set the query parameters as path parameters.