### PR TITLE
schema reference resolution

### DIFF
--- a/__tests__/lib/openapi/constructor.spec.js
+++ b/__tests__/lib/openapi/constructor.spec.js
@@ -913,5 +913,551 @@ describe('openapi constructor', () => {
 
       await expect(swParser.validate(api)).resolves.toEqual(api);
     });
+    describe('should substitute references', () => {
+      const schemas = {
+        sch1: {
+          type: 'object',
+          description: 'sch1 schema',
+          properties: {
+            num: {
+              type: 'number',
+              minimum: 1,
+              maximum: 1000,
+              description: 'some number',
+            },
+            str: {
+              enum: ['a', 'b', 'c'],
+              default: 'b',
+              description: 'some string',
+              type: 'string',
+            },
+          },
+        },
+        sch2: {
+          type: 'object',
+          description: 'sch2 schema',
+          properties: {
+            num: {
+              type: 'number',
+              title: 'title',
+              minimum: 1,
+              maximum: 1000,
+              description: 'some number',
+            },
+            str: {
+              enum: ['a', 'b', 'c'],
+              default: 'b',
+              description: 'some string',
+              type: 'string',
+            },
+            ref: {
+              $ref: 'sch1#',
+            },
+          },
+        },
+      };
+      const getSchema = (id) => schemas[id];
+      test('in querystring', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                querystring: {
+                  $ref: 'sch1#',
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              parameters: [
+                {
+                  description: schemas.sch1.properties.num.description,
+                  in: 'query',
+                  name: 'num',
+                  schema: schemas.sch1.properties.num,
+                },
+                {
+                  description: schemas.sch1.properties.str.description,
+                  in: 'query',
+                  name: 'str',
+                  schema: schemas.sch1.properties.str,
+                },
+              ],
+              responses: {
+                '200': {
+                  description: 'Default Response',
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+      test('in body', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                body: {
+                  $ref: 'sch1#',
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              requestBody: {
+                description: schemas.sch1.description,
+                content: {
+                  '*/*': {
+                    schema: Object.assign({}, schemas.sch1, {
+                      description: undefined,
+                    }),
+                  },
+                },
+              },
+              responses: {
+                '200': {
+                  description: 'Default Response',
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+      test('in params', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                params: {
+                  $ref: 'sch1#',
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              parameters: [
+                {
+                  description: schemas.sch1.properties.num.description,
+                  in: 'path',
+                  name: 'num',
+                  required: true,
+                  schema: schemas.sch1.properties.num,
+                },
+                {
+                  description: schemas.sch1.properties.str.description,
+                  in: 'path',
+                  name: 'str',
+                  required: true,
+                  schema: schemas.sch1.properties.str,
+                },
+              ],
+              responses: {
+                '200': {
+                  description: 'Default Response',
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+      test('in headers', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                headers: {
+                  $ref: 'sch1#',
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              parameters: [
+                {
+                  description: schemas.sch1.properties.num.description,
+                  in: 'header',
+                  name: 'num',
+                  schema: schemas.sch1.properties.num,
+                },
+                {
+                  description: schemas.sch1.properties.str.description,
+                  in: 'header',
+                  name: 'str',
+                  schema: schemas.sch1.properties.str,
+                },
+              ],
+              responses: {
+                '200': {
+                  description: 'Default Response',
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+      test('in cookies', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                cookies: {
+                  $ref: 'sch1#',
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              parameters: [
+                {
+                  description: schemas.sch1.properties.num.description,
+                  in: 'cookie',
+                  name: 'num',
+                  schema: schemas.sch1.properties.num,
+                },
+                {
+                  description: schemas.sch1.properties.str.description,
+                  in: 'cookie',
+                  name: 'str',
+                  schema: schemas.sch1.properties.str,
+                },
+              ],
+              responses: {
+                '200': {
+                  description: 'Default Response',
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+      test('in responses', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                response: {
+                  200: {
+                    $ref: 'sch1#',
+                  },
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              responses: {
+                '200': {
+                  description: schemas.sch1.description,
+                  content: {
+                    '*/*': {
+                      schema: schemas.sch1,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+      test('in nested references', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                response: {
+                  200: {
+                    $ref: 'sch2#',
+                  },
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              responses: {
+                '200': {
+                  description: schemas.sch2.description,
+                  content: {
+                    '*/*': {
+                      schema: Object.assign({}, schemas.sch2, {
+                        properties: Object.assign({}, schemas.sch2.properties, {
+                          ref: schemas.sch1,
+                        }),
+                      }),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+      test('in array of references', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                response: {
+                  200: {
+                    description: 'an array',
+                    type: 'array',
+                    items: {
+                      $ref: 'sch1#',
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'an array',
+                  content: {
+                    '*/*': {
+                      schema: {
+                        type: 'array',
+                        description: 'an array',
+                        items: schemas.sch1,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+      test('in anyOf with references', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                response: {
+                  200: {
+                    description: 'any of',
+                    type: 'object',
+                    anyOf: [
+                      {
+                        type: 'object',
+                        properties: {
+                          inlineProp1: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                      {
+                        $ref: 'sch1#',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'any of',
+                  content: {
+                    '*/*': {
+                      schema: {
+                        description: 'any of',
+                        type: 'object',
+                        anyOf: [
+                          {
+                            type: 'object',
+                            properties: {
+                              inlineProp1: {
+                                type: 'string',
+                              },
+                            },
+                          },
+                          schemas.sch1,
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+      test('in allOf with references', async () => {
+        const api = openapi({
+          options: {},
+          getSchema,
+          routes: [
+            {
+              logLevel: '',
+              method: 'GET',
+              path: '/api/ep',
+              url: '/api/ep',
+              prefix: '/api',
+              schema: {
+                response: {
+                  200: {
+                    description: 'all of',
+                    type: 'object',
+                    allOf: [
+                      {
+                        type: 'object',
+                        properties: {
+                          inlineProp1: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                      {
+                        $ref: 'sch1#',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        })();
+        expect(api).toHaveProperty('paths', {
+          '/api/ep': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'all of',
+                  content: {
+                    '*/*': {
+                      schema: {
+                        description: 'all of',
+                        type: 'object',
+                        allOf: [
+                          {
+                            type: 'object',
+                            properties: {
+                              inlineProp1: {
+                                type: 'string',
+                              },
+                            },
+                          },
+                          schemas.sch1,
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        await expect(swParser.validate(api)).resolves.toEqual(api);
+      });
+    });
   });
 });

--- a/lib/openapi/constructor.js
+++ b/lib/openapi/constructor.js
@@ -47,6 +47,11 @@ const get = (value, path, defaultValue) =>
 
 const set = (obj, path, value) => {
   if (Object(obj) !== obj) return obj;
+  if (!path) {
+    // Object is a reference, substitute with resolved schema
+    Reflect.deleteProperty(obj, '$ref');
+    return Object.assign(obj, value);
+  }
   if (!Array.isArray(path)) path = path.toString().match(/[^.[\]]+/g) || [];
   path
     .slice(0, -1)
@@ -81,6 +86,28 @@ module.exports = ({
   const cache = {
     swaggerObject: null,
     swaggerString: null,
+  };
+
+  const resolveReferences = (schema, cache = {}) => {
+    if (schema) {
+      const flat = flattenObject(schema);
+      const refs = Object.keys(flat).filter((k) => k.indexOf('$ref') > -1);
+      refs.forEach((ref) => {
+        const refValue = get(schema, ref);
+        if (refValue.indexOf('#') === refValue.length - 1) {
+          const schemaId = refValue.substring(0, refValue.indexOf('#'));
+          const resolved =
+            cache[schemaId] || (cache[schemaId] = getSchema(schemaId));
+          set(
+            schema,
+            ref.substring(0, ref.indexOf('$ref')),
+            resolveReferences(resolved, cache)
+          );
+        }
+      });
+    }
+
+    return schema;
   };
 
   const handler = (opts = {}) => {
@@ -217,137 +244,41 @@ module.exports = ({
         }
 
         if (schema.querystring) {
-          const flat = flattenObject(schema.querystring);
-          const refs = Object.keys(flat).filter((k) => k.indexOf('$ref') > -1);
-          if (refs.length > 0) {
-            refs.forEach((ref) => {
-              const refValue = get(schema.querystring, ref);
-              if (refValue.indexOf('#') === refValue.length - 1) {
-                const schemaId = refValue.substring(0, refValue.indexOf('#'));
-                const resolved = getSchema(schemaId);
-                helpers.genQuery(parameters, resolved);
-              }
-            });
-          } else {
-            helpers.genQuery(parameters, schema.querystring);
-          }
+          resolveReferences(schema.querystring);
+          helpers.genQuery(parameters, schema.querystring);
         }
 
         if (schema.body) {
           swaggerMethod.requestBody = {};
-          const flat = flattenObject(schema.body);
-          const refs = Object.keys(flat).filter((k) => k.indexOf('$ref') > -1);
-          if (refs.length > 0) {
-            refs.forEach((ref) => {
-              const refValue = get(schema.body, ref);
-              if (refValue.indexOf('#') === refValue.length - 1) {
-                const schemaId = refValue.substring(0, refValue.indexOf('#'));
-                const resolved = getSchema(schemaId);
-                helpers.genBody(
-                  swaggerMethod.requestBody,
-                  resolved,
-                  schema.consumes
-                );
-              }
-            });
-          } else {
-            helpers.genBody(
-              swaggerMethod.requestBody,
-              schema.body,
-              schema.consumes
-            );
-          }
+          resolveReferences(schema.body);
+          helpers.genBody(
+            swaggerMethod.requestBody,
+            schema.body,
+            schema.consumes
+          );
         }
 
         if (schema.params) {
-          const flat = flattenObject(schema.params);
-          const refs = Object.keys(flat).filter((k) => k.indexOf('$ref') > -1);
-          if (refs.length > 0) {
-            refs.forEach((ref) => {
-              const refValue = get(schema.params, ref);
-              if (refValue.indexOf('#') === refValue.length - 1) {
-                const schemaId = refValue.substring(0, refValue.indexOf('#'));
-                const resolved = getSchema(schemaId);
-                set(
-                  schema.params,
-                  ref.substring(0, ref.indexOf('$ref')),
-                  resolved
-                );
-                helpers.genPath(parameters, schema.params);
-              }
-            });
-          } else {
-            helpers.genPath(parameters, schema.params);
-          }
+          resolveReferences(schema.params);
+          helpers.genPath(parameters, schema.params);
         }
 
         if (schema.headers) {
-          const flat = flattenObject(schema.headers);
-          const refs = Object.keys(flat).filter((k) => k.indexOf('$ref') > -1);
-          if (refs.length > 0) {
-            refs.forEach((ref) => {
-              const refValue = get(schema.headers, ref);
-              if (refValue.indexOf('#') === refValue.length - 1) {
-                const schemaId = refValue.substring(0, refValue.indexOf('#'));
-                const resolved = getSchema(schemaId);
-                helpers.genHeaders(parameters, resolved);
-              }
-            });
-          } else {
-            helpers.genHeaders(parameters, schema.headers);
-          }
+          resolveReferences(schema.headers);
+          helpers.genHeaders(parameters, schema.headers);
         }
 
         if (schema.cookies) {
-          const flat = flattenObject(schema.cookies);
-          const refs = Object.keys(flat).filter((k) => k.indexOf('$ref') > -1);
-          if (refs.length > 0) {
-            refs.forEach((ref) => {
-              const refValue = get(schema.cookies, ref);
-              if (refValue.indexOf('#') === refValue.length - 1) {
-                const schemaId = refValue.substring(0, refValue.indexOf('#'));
-                const resolved = getSchema(schemaId);
-                helpers.genCookies(parameters, resolved);
-              }
-            });
-          } else {
-            helpers.genCookies(parameters, schema.cookies);
-          }
+          resolveReferences(schema.cookies);
+          helpers.genCookies(parameters, schema.cookies);
         }
 
-        if (schema.response) {
-          const flat = flattenObject(schema.response);
-          const refs = Object.keys(flat).filter((k) => k.indexOf('$ref') > -1);
-          if (refs.length > 0) {
-            refs.forEach((ref) => {
-              const code = ref.split('.')[0];
-              const refValue = get(schema.response, ref);
-              if (refValue.indexOf('#') === refValue.length - 1) {
-                const schemaId = refValue.substring(0, refValue.indexOf('#'));
-                const resolved = getSchema(schemaId);
-                const ret = {};
-                ret[code] = resolved;
-                helpers.genResponse(
-                  swaggerMethod.responses,
-                  ret,
-                  schema.produces
-                );
-              }
-            });
-          } else {
-            helpers.genResponse(
-              swaggerMethod.responses,
-              schema.response || { 200: { description: 'Default Response' } },
-              schema.produces
-            );
-          }
-        } else {
-          helpers.genResponse(
-            swaggerMethod.responses,
-            schema.response || { 200: { description: 'Default Response' } },
-            schema.produces
-          );
-        }
+        resolveReferences(schema.response);
+        helpers.genResponse(
+          swaggerMethod.responses,
+          schema.response || { 200: { description: 'Default Response' } },
+          schema.produces
+        );
 
         if (parameters.length) {
           swaggerMethod.parameters = parameters;


### PR DESCRIPTION
This is a small refactoring of the schema reference resolution code. It works for all my use cases so far but it's possible that I'm missing something. Would you mind reviewing it?

It mainly fixes some issues where schemas that contain references among other definitions were replaced with the resolved references only.

~~Question: would you mind if I added a setting that completely disables schema reference resolution? If true, all referenced schemas would be expected to be reachable directly by the UI.~~

~~Also added a new option: `disableSchemaReferenceResolution`
If truthy, schema reference resolution is disabled and all schema references are expected to be valid URIs. The default behavior is still to resolve and replace them inline.~~ - Gave up on this for now, as the rest of the code won't support it.
