### PR TITLE
fix: add support for url parameters

### DIFF
--- a/__tests__/lib/helpers.spec.js
+++ b/__tests__/lib/helpers.spec.js
@@ -343,6 +343,29 @@ describe('helpers', () => {
       helpers.genPath(dst, params);
       expect(dst).toEqual(expected);
     });
+    test('generates valid url params', () => {
+      const dst = [];
+      const expected = [
+        {
+          description: 'user id',
+          in: 'query',
+          name: 'id',
+          schema: { description: 'user id', type: 'string' },
+        },
+      ];
+      const params = {
+        type: 'object',
+        properties: {
+          id: {
+            in: 'query',
+            type: 'string',
+            description: 'user id',
+          },
+        },
+      };
+      helpers.genPath(dst, params);
+      expect(dst).toEqual(expected);
+    });
   });
 
   describe('genResponse', () => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -148,7 +148,8 @@ const gentShorthandParams = (inWhat) => {
         in: inWhat,
       };
 
-      if (val.required || inWhat === 'path') param.required = true;
+      if (val.in) param.in = params[name].in;
+      if (val.required || param.in === 'path') param.required = true;
       if (typeof val.description !== 'undefined') {
         param.description = val.description;
       }


### PR DESCRIPTION
URL query params in schema are not supported and is automatically replaced with 'path' and marked as 'required' in the helper function.

```javascript
fastify.get('/some-secrete-route/:id', {
  schema: {
    hide: true,
    params: {
      type: 'object',
      properties: {
        id: {
          type: 'string',
          description: 'user id'
        }
        urlParam: {
          in: 'query',
          type: 'string',
          description: 'optional url parameter'
        }
      }
    },
    response: {
      201: {
        description: 'Successful response',
        type: 'object',
        properties: {
          hello: { type: 'string' }
        }
      }
    },
  }
}, (req, reply) => {})
'''

Updated helper.js to account for param types that aren't paths.