### PR TITLE
fix: bump swagger-ui-dist to 3.36.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9927,9 +9927,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "3.32.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.32.1.tgz",
-      "integrity": "sha512-CaIKxDo91McgoesukS5v3nwQ8iur0MQmwNvJ+bPeyd8sOtoiNyXp55ZjO4pXewBdFHD0f9PvGovf2m5x/1typA==",
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.36.1.tgz",
+      "integrity": "sha512-p7lx/OubaaCzOfSYDuMbkRvf/a+rTnQAOySN/NhL+k6D5o9WXEEeKZwj/6fRHRoLSHKZq28jc1xQcz8HuYcgwQ==",
       "dev": true
     },
     "swagger2openapi": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "redoc": "^2.0.0-rc.36",
     "replace": "^1.2.0",
     "standard-version": "^9.0.0",
-    "swagger-ui-dist": "^3.32.1",
+    "swagger-ui-dist": "^3.36.1",
     "typedoc": "^0.18.0",
     "typedoc-plugin-markdown": "^2.4.0",
     "typescript": "^3.9.7"


### PR DESCRIPTION
Updates the swagger ui to the latest and greatest, includes this notable issue: https://github.com/swagger-api/swagger-ui/issues/6305.

I verified locally:
- npm pack
- npm install reference to local package
- re-run my server and view the swagger UI docs
- visit the console and check the `versions` object matches `3.36.1`

![Screenshot 2020-11-03 at 22 26 37](https://user-images.githubusercontent.com/1939483/98047356-abcd9e00-1e23-11eb-9384-38fbb51149af.png)
