### PR TITLE
Fix to CSP-Violation for redoc usage

### DIFF
--- a/lib/openapi/index.js
+++ b/lib/openapi/index.js
@@ -6,7 +6,7 @@ function getSchemasRecursive(instance) {
   const schemas = {};
   Object.assign(schemas, instance.getSchemas());
   const children = instance[symbols.kChildren];
-  if (children.length) {
+  if (children && children.length) {
     children.forEach((child) => {
       Object.assign(schemas, getSchemasRecursive(child));
     });

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -15,7 +15,8 @@ async function oasRoutes(fastify, options) {
       },
     });
     const swaggerCspHeader =
-      "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' 'unsafe-inline' data: ; object-src 'none'";
+      "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' 'unsafe-inline' data: ; object-src 'none'; worker-src 'self' blob:;";
+
     fastify.register(fstatic, {
       setHeaders: (res) => {
         res.setHeader('Content-Security-Policy', swaggerCspHeader);


### PR DESCRIPTION
Swagger works (`.../index.html`) but redoc (`.../docs.html`) errors complaining about CSP-Violation like: 

```
Failed to construct 'Worker': Access to the script at 'blob: [...]
```

As per https://github.com/Redocly/redoc/issues/764, adding `worker-src 'self' blob:;` to CSP-headers resolves that.

Besides, I just ran into an issue with undefined `children` (fastify-oas/lib/openapi/index.js:9:16), which is out of the scope of this PR and should be investigated further, I guess. But had to "workaround"  to get that CSP fix in place.